### PR TITLE
Fix README deployment code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ git clone https://github.com/ruvel-ai-dev/ShyletiNews.git
 cd ShyletiNews
 pip install -r requirements.txt
 python app.py
----
+
+```
+
+Once the server is running, open `http://localhost:5000` in your browser to
+access the site.
+
 
 


### PR DESCRIPTION
## Summary
- close deployment code block in README
- add instructions on how to view the running server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869bb437dc8832cb773c23cf9a17b30