### PR TITLE
Update default SQLite path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,10 @@ python app.py
 Once the server is running, open `http://localhost:5000` in your browser to
 access the site.
 
+The application stores its SQLite database in `instance/news_scraper.db` by
+default. Ensure the `instance` directory exists (it is created automatically
+when running the app) or adjust the location by setting the `DATABASE_URL`
+environment variable.
+
 
 

--- a/app.py
+++ b/app.py
@@ -19,7 +19,9 @@ app.secret_key = os.environ.get("SESSION_SECRET", "fallback-secret-key-for-devel
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
 # Configure the database
-app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("DATABASE_URL", "sqlite:///news_scraper.db")
+app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
+    "DATABASE_URL", "sqlite:///instance/news_scraper.db"
+)
 app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
     "pool_recycle": 300,
     "pool_pre_ping": True,

--- a/replit.md
+++ b/replit.md
@@ -79,6 +79,7 @@ This is a Flask-based web application that scrapes news articles from various so
 
 ### Infrastructure
 - SQLite: Default database (configurable to PostgreSQL)
+- Database file stored at `instance/news_scraper.db` by default
 - Environment variables for configuration
 - ProxyFix middleware for deployment behind proxies
 


### PR DESCRIPTION
## Summary
- update `app.py` to default to `instance/news_scraper.db`
- document the database location in README and replit notes

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(ls *.py)`
- `python test_scrapers.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869bc2ee4b0832cbd1d4e32809fc6ad