### PR TITLE
Start scheduler on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,4 +38,6 @@ with app.app_context():
 import routes
 
 if __name__ == "__main__":
+    from scheduler import start_background_scheduler
+    start_background_scheduler()
     app.run(host="0.0.0.0", port=5000, debug=True)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 from app import app
+from scheduler import start_background_scheduler
 
 if __name__ == "__main__":
+    start_background_scheduler()
     app.run(host="0.0.0.0", port=5000, debug=True)


### PR DESCRIPTION
## Summary
- start the background scheduler when the app starts

## Testing
- `pytest -q` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869bc3a43b4832cbb81474aa282a268