### PR TITLE
Add gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Ignore Python cache directories and compiled files
+__pycache__/
+*.py[cod]
+
+# Ignore testing and coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Ignore virtual environments
+.env/
+.venv/
+ENV/
+venv/
+
+# Ignore build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Ignore database and local instance files
+instance/news_scraper.db
+
+# Ignore logs
+*.log
+
+# macOS/Linux system files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude generated database, caches and build artifacts

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869bc4367d8832c861417b9085a4169